### PR TITLE
docs: update tap instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ associated with manual operations.
 Via Homebrew
 
 ```shell
-$ brew tap atlassian-labs/acli
+$ brew tap atlassian/acli
 
 $ brew install acli
 ```


### PR DESCRIPTION
Repo was recently relocated from `atlassian-labs` to `atlassian`, so the instructions need to be updated.