### PR TITLE
Document Homebrew tap trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ $ brew tap atlassian-labs/acli
 $ brew install acli
 ```
 
+### Homebrew tap trust
+
+Homebrew 6 can require non-official taps to be trusted before installing or
+upgrading formulae from them. If Homebrew reports that the ACLI tap is not
+trusted, trust the tap name shown in the warning before retrying:
+
+```shell
+$ brew trust atlassian/acli
+```
+
+Only trust the tap if you trust this repository and the formulae it provides.
+
 ## License
 
 Copyright (c) 2025 Atlassian US., Inc.


### PR DESCRIPTION
## Summary

- Document the Homebrew 6 tap trust warning for ACLI installs/upgrades.
- Show `brew trust atlassian/acli` while advising users to only trust the tap when they trust the repository and formulae.

Fixes #54.

## Validation

- `git diff --check`
